### PR TITLE
1.3.0 Submission - Multiple Additions/Edits

### DIFF
--- a/DiscordIntegration/EventHandlers.cs
+++ b/DiscordIntegration/EventHandlers.cs
@@ -177,6 +177,13 @@ namespace DiscordIntegration_Plugin
 					ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasJoinedTheGame}.", HandleQueue.GameLogChannelId);
 		}
 
+		public void OnPlayerLeave(PlayerLeaveEvent ev)
+		{
+			if (plugin.PlayerLeave)
+				if (ev.Player.nicknameSync.MyNick != "Dedicated Server")
+					ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasLeftTheGame}.", HandleQueue.GameLogChannelId);
+		}
+
 		public void OnPlayerFreed(ref HandcuffEvent ev)
 		{
 			if (plugin.Freed)
@@ -290,6 +297,12 @@ namespace DiscordIntegration_Plugin
 		{
 			if (plugin.Scp914KnobChange)
 				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.scp914knobchange} {ev.KnobSetting}.", HandleQueue.GameLogChannelId);
+		}
+
+		public void OnPlayerEnterFemur (FemurEnterEvent ev)
+		{
+			if (plugin.EnterFemur)
+				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasEnteredFemur}.", HandleQueue.GameLogChannelId);
 		}
 	}
 }

--- a/DiscordIntegration/EventHandlers.cs
+++ b/DiscordIntegration/EventHandlers.cs
@@ -109,12 +109,12 @@ namespace DiscordIntegration_Plugin
 				{
 					if (ev.Attacker != null && ev.Attacker.characterClassManager != null && Player.GetTeam(ev.Player.characterClassManager.CurClass) == Player.GetTeam(ev.Attacker.characterClassManager.CurClass) && ev.Player != ev.Attacker)
 						ProcessSTT.SendData(
-							$"{emote}**{ev.Attacker.nicknameSync.MyNick} - {ev.Attacker.characterClassManager.UserId} ({ev.Attacker.characterClassManager.CurClass}) {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.Tool}.**",
+							$"{emote}**{ev.Attacker.nicknameSync.MyNick} - {ev.Attacker.characterClassManager.UserId} ({ev.Attacker.characterClassManager.CurClass}) {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.GetDamageName()}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!plugin.OnlyFriendlyFire)
 					{
 						ProcessSTT.SendData(
-							$"{emote}{ev.Info.Attacker}  {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.Tool}.",
+							$"{emote}{ev.Info.Attacker}  {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.GetDamageName()}.",
 							HandleQueue.GameLogChannelId);
 					}
 				}
@@ -136,12 +136,12 @@ namespace DiscordIntegration_Plugin
 				{
 					if (ev.Killer != null && ev.Killer.characterClassManager != null && Player.GetTeam(ev.Player.characterClassManager.CurClass) == Player.GetTeam(ev.Killer.characterClassManager.CurClass))
 						ProcessSTT.SendData(
-							$"{emote}**{ev.Killer.nicknameSync.MyNick} - {ev.Killer.characterClassManager.UserId} ({ev.Killer.characterClassManager.CurClass}) {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.Tool}.**",
+							$"{emote}**{ev.Killer.nicknameSync.MyNick} - {ev.Killer.characterClassManager.UserId} ({ev.Killer.characterClassManager.CurClass}) {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.GetDamageName()}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!plugin.OnlyFriendlyFire)
 					{
 						ProcessSTT.SendData(
-							$"{emote}{ev.Info.Attacker} {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.Tool}.",
+							$"{emote}{ev.Info.Attacker} {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.GetDamageName()}.",
 							HandleQueue.GameLogChannelId);
 					}
 				}

--- a/DiscordIntegration/EventHandlers.cs
+++ b/DiscordIntegration/EventHandlers.cs
@@ -72,7 +72,7 @@ namespace DiscordIntegration_Plugin
 				emote = ":zap: ";
 
 			if (plugin.RoundStart)
-				ProcessSTT.SendData($"{emote}{Plugin.translation.roundStarting}: {Plugin.GetHubs().Count} {Plugin.translation.playersInRound}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{Plugin.translation.roundStarting}: {Plugin.GetHubs().Count - 1} {Plugin.translation.playersInRound}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnRoundEnd()
@@ -185,7 +185,7 @@ namespace DiscordIntegration_Plugin
 
 			if (plugin.SetClass)
 			{
-				if (ev.Player == null)
+				if (ev.Player == null || ev.Player.nicknameSync.MyNick == "Dedicated Server")
 					return;
 				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasBenChangedToA} {ev.Role}.", HandleQueue.GameLogChannelId);
 			}

--- a/DiscordIntegration/EventHandlers.cs
+++ b/DiscordIntegration/EventHandlers.cs
@@ -14,11 +14,15 @@ namespace DiscordIntegration_Plugin
 	{
 		private readonly Plugin plugin;
 		public EventHandlers(Plugin plugin) => this.plugin = plugin;
+		string emote = "";
 		
 		public void OnCommand(ref RACommandEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":keyboard: ";
+
 			if (plugin.RaCommands)
-				ProcessSTT.SendData($"{ev.Sender.Nickname} {Plugin.translation.usedCommand}: {ev.Command}", HandleQueue.CommandLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Sender.Nickname} {Plugin.translation.usedCommand}: {ev.Command}", HandleQueue.CommandLogChannelId);
 			if (ev.Command.ToLower() == "list")
 			{
 				ev.Allow = false;
@@ -55,42 +59,54 @@ namespace DiscordIntegration_Plugin
 
 		public void OnWaitingForPlayers()
 		{
+			if (plugin.EmoteLogs)
+				emote = ":white_check_mark: ";
+
 			if (plugin.WaitingForPlayers)
-				ProcessSTT.SendData($"{Plugin.translation.waitingForPlayers}", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{Plugin.translation.waitingForPlayers}", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnRoundStart()
 		{
+			if (plugin.EmoteLogs)
+				emote = ":zap: ";
+
 			if (plugin.RoundStart)
-				ProcessSTT.SendData($"{Plugin.translation.roundStarting}: {Plugin.GetHubs().Count} {Plugin.translation.playersInRound}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{Plugin.translation.roundStarting}: {Plugin.GetHubs().Count} {Plugin.translation.playersInRound}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnRoundEnd()
 		{
 			if (plugin.RoundEnd)
-				ProcessSTT.SendData($"{Plugin.translation.roundEnded}: {Plugin.GetHubs().Count} {Plugin.translation.playersOnline}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{Plugin.translation.roundEnded}: {Plugin.GetHubs().Count} {Plugin.translation.playersOnline}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnCheaterReport(ref CheaterReportEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":warning: ";
+
 			if (plugin.CheaterReport)
-				ProcessSTT.SendData($"**{Plugin.translation.cheaterReportFiled}: {ev.ReporterId} {Plugin.translation.reported} {ev.ReportedId} {Plugin.translation._for} {ev.Report}.**", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}**{Plugin.translation.cheaterReportFiled}: {ev.ReporterId} {Plugin.translation.reported} {ev.ReportedId} {Plugin.translation._for} {ev.Report}.**", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerHurt(ref PlayerHurtEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":red_circle: ";
+
 			if (plugin.PlayerHurt)
 			{
 				try
 				{
 					if (ev.Attacker != null && ev.Attacker.characterClassManager != null && Player.GetTeam(ev.Player.characterClassManager.CurClass) == Player.GetTeam(ev.Attacker.characterClassManager.CurClass) && ev.Player != ev.Attacker)
 						ProcessSTT.SendData(
-							$"**{ev.Attacker.nicknameSync.MyNick} - {ev.Attacker.characterClassManager.UserId} ({ev.Attacker.characterClassManager.CurClass}) {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.Tool}.**",
+							$"{emote}**{ev.Attacker.nicknameSync.MyNick} - {ev.Attacker.characterClassManager.UserId} ({ev.Attacker.characterClassManager.CurClass}) {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.Tool}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!plugin.OnlyFriendlyFire)
 					{
 						ProcessSTT.SendData(
-							$"{ev.Info.Attacker}  {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.Tool}.",
+							$"{emote}{ev.Info.Attacker}  {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.Tool}.",
 							HandleQueue.GameLogChannelId);
 					}
 				}
@@ -103,18 +119,21 @@ namespace DiscordIntegration_Plugin
 		
 		public void OnPlayerDeath(ref PlayerDeathEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":skull: ";
+
 			if (plugin.PlayerDeath)
 			{
 				try
 				{
 					if (ev.Killer != null && ev.Killer.characterClassManager != null && Player.GetTeam(ev.Player.characterClassManager.CurClass) == Player.GetTeam(ev.Killer.characterClassManager.CurClass))
 						ProcessSTT.SendData(
-							$"**{ev.Killer.nicknameSync.MyNick} - {ev.Killer.characterClassManager.UserId} ({ev.Killer.characterClassManager.CurClass}) {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.Tool}.**",
+							$"{emote}**{ev.Killer.nicknameSync.MyNick} - {ev.Killer.characterClassManager.UserId} ({ev.Killer.characterClassManager.CurClass}) {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.Tool}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!plugin.OnlyFriendlyFire)
 					{
 						ProcessSTT.SendData(
-							$"{ev.Info.Attacker} {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.Tool}.",
+							$"{emote}{ev.Info.Attacker} {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.Tool}.",
 							HandleQueue.GameLogChannelId);
 					}
 				}
@@ -127,36 +146,51 @@ namespace DiscordIntegration_Plugin
 
 		public void OnGrenadeThrown(ref GrenadeThrownEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":bomb: ";
+
 			if (plugin.GrenadeThrown)
 			{
 				if (ev.Player == null)
 					return;
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.threwAGrenade}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.threwAGrenade}.", HandleQueue.GameLogChannelId);
 			}
 		}
 
 		public void OnMedicalItem(MedicalItemEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":pill: ";
+
 			if (plugin.MedicalItem)
 			{
 				if (ev.Player == null)
 					return;
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.userA} {ev.Item}", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.userA} {ev.Item}", HandleQueue.GameLogChannelId);
 			}
 		}
 
 		public void OnSetClass(SetClassEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":mens: ";
+
 			if (plugin.SetClass)
 			{
 				if (ev.Player == null)
 					return;
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasBenChangedToA} {ev.Role}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasBenChangedToA} {ev.Role}.", HandleQueue.GameLogChannelId);
 			}
 		}
 
 		public void OnRespawn(ref TeamRespawnEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				if (ev.IsChaos)
+					emote = ":spy: ";
+				else
+					emote = ":cop: ";
+
 			if (plugin.Respawn)
 			{
 				string msg;
@@ -164,107 +198,152 @@ namespace DiscordIntegration_Plugin
 					msg = $"{Plugin.translation.chaosInsurgency}";
 				else
 					msg = $"{Plugin.translation.nineTailedFox}";
-				ProcessSTT.SendData($"{msg} {Plugin.translation.hasSpawnedWith} {ev.ToRespawn.Count} {Plugin.translation.players}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{msg} {Plugin.translation.hasSpawnedWith} {ev.ToRespawn.Count} {Plugin.translation.players}.", HandleQueue.GameLogChannelId);
 			}
 		}
 
 		public void OnPlayerJoin(PlayerJoinEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":arrow_forward: ";
+
 			if (plugin.RoleSync)
 				Methods.CheckForSyncRole(ev.Player);
 			if (plugin.PlayerJoin)
 				if (ev.Player.nicknameSync.MyNick != "Dedicated Server")
-					ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasJoinedTheGame}.", HandleQueue.GameLogChannelId);
+					ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasJoinedTheGame}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerLeave(PlayerLeaveEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":arrow_backward: ";
+
 			if (plugin.PlayerLeave)
 				if (ev.Player.nicknameSync.MyNick != "Dedicated Server")
-					ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasLeftTheGame}.", HandleQueue.GameLogChannelId);
+					ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasLeftTheGame}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerFreed(ref HandcuffEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":link: ";
+
 			if (plugin.Freed)
 				ProcessSTT.SendData(
-					$"{ev.Target.nicknameSync.MyNick} - {ev.Target.characterClassManager.UserId} ({ev.Target.characterClassManager.CurClass}) {Plugin.translation.hasBeenFreedBy} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass})",
+					$"{emote}{ev.Target.nicknameSync.MyNick} - {ev.Target.characterClassManager.UserId} ({ev.Target.characterClassManager.CurClass}) {Plugin.translation.hasBeenFreedBy} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass})",
 						HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerHandcuffed(ref HandcuffEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":link: ";
+
 			if (plugin.Cuffed)
 				ProcessSTT.SendData(
-					$"{ev.Target.nicknameSync.MyNick} - {ev.Target.characterClassManager.UserId} ({ev.Target.characterClassManager.CurClass}) {Plugin.translation.hasBeenHandcuffedBy} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass})",
+					$"{emote}{ev.Target.nicknameSync.MyNick} - {ev.Target.characterClassManager.UserId} ({ev.Target.characterClassManager.CurClass}) {Plugin.translation.hasBeenHandcuffedBy} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass})",
 						HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerBanned(PlayerBannedEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":no_entry: ";
+
 			if (plugin.Banned)
-				ProcessSTT.SendData($"{ev.Details.OriginalName} - {ev.Details.Id} {Plugin.translation.wasBannedBy} {ev.Details.Issuer} {Plugin.translation._for} {ev.Details.Reason}. {DateTime.Now.AddTicks(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Details.OriginalName} - {ev.Details.Id} {Plugin.translation.wasBannedBy} {ev.Details.Issuer} {Plugin.translation._for} {ev.Details.Reason}. {DateTime.Now.AddTicks(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
 		}
 
 		public void OnIntercomSpeak(ref IntercomSpeakEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":loud_sound: ";
+
 			if (plugin.Intercom)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasStartedUsingTheIntercom}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasStartedUsingTheIntercom}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPickupItem(ref PickupItemEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":inbox_tray: ";
+
 			if (plugin.PickupItem)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasPickedUp} {ev.Item.ItemId}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasPickedUp} {ev.Item.ItemId}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnDropItem(ref DropItemEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":outbox_tray: ";
+
 			if (plugin.DropItem)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasDropped} {ev.Item.id}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasDropped} {ev.Item.id}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnDecon(ref DecontaminationEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":biohazard: ";
+
 			if (plugin.Decon)
-				ProcessSTT.SendData($"{Plugin.translation.hasDropped}.", HandleQueue.CommandLogChannelId);
+				ProcessSTT.SendData($"{emote}{Plugin.translation.hasDropped}.", HandleQueue.CommandLogChannelId);
 		}
 
 		public void OnConsoleCommand(ConsoleCommandEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":keyboard: ";
+
 			if (plugin.ConsoleCommand)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.CurClass} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasRunClientConsoleCommand}: {ev.Command}", HandleQueue.CommandLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.CurClass} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasRunClientConsoleCommand}: {ev.Command}", HandleQueue.CommandLogChannelId);
 		}
 
 		public void OnPocketEnter(PocketDimEnterEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":door: ";
+
 			if (plugin.PocketEnter)
 				ProcessSTT.SendData(
-					$"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.CurClass} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasEnteredPocketDimension}.",
+					$"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.CurClass} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasEnteredPocketDimension}.",
 					HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPocketEscape(PocketDimEscapedEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":door: ";
+
 			if (plugin.PocketEscape)
 				ProcessSTT.SendData(
-					$"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.CurClass} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasEscapedPocketDimension}.",
+					$"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.CurClass} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasEscapedPocketDimension}.",
 					HandleQueue.GameLogChannelId);		}
 
 		public void On106Teleport(Scp106TeleportEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":eight_pointed_black_star: ";
+
 			if (plugin.Scp106Tele)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasEscapedPocketDimension}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} {Plugin.translation.hasEscapedPocketDimension}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void On079Tesla(ref Scp079TriggerTeslaEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":zap: ";
+
 			if (plugin.Scp079Tesla)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasTriggeredATeslaGate}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasTriggeredATeslaGate}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnScp194Upgrade(ref SCP914UpgradeEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":control_knobs: ";
+
 			if (plugin.Scp914Upgrade)
 			{
 				string players = "";
@@ -274,35 +353,47 @@ namespace DiscordIntegration_Plugin
 				foreach (Pickup item in ev.Items)
 					items += $"{item.ItemId}\n";
 				
-				ProcessSTT.SendData($"{Plugin.translation.scp914HasProcessedTheFollowingPlayers}: {players} {Plugin.translation.andItems}: {items}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{Plugin.translation.scp914HasProcessedTheFollowingPlayers}: {players} {Plugin.translation.andItems}: {items}.", HandleQueue.GameLogChannelId);
 			}
 		}
 
 		public void OnDoorInteract(ref DoorInteractionEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":door: ";
+
 			if (plugin.DoorInteract)
 				ProcessSTT.SendData(ev.Door.NetworkisOpen
-						? $"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasClosedADoor}: {ev.Door.DoorName}."
-						: $"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasOpenedADoor}: {ev.Door.DoorName}.",
+						? $"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasClosedADoor}: {ev.Door.DoorName}."
+						: $"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasOpenedADoor}: {ev.Door.DoorName}.",
 					HandleQueue.GameLogChannelId);
 		}
 
 		public void On914Activation(ref Scp914ActivationEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":control_knobs: ";
+
 			if (plugin.Scp914Activation)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.scp914HasBeenActivated} {Scp914Machine.singleton.knobState}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.scp914HasBeenActivated} {Scp914Machine.singleton.knobState}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void On914KnobChange(ref Scp914KnobChangeEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":control_knobs: ";
+
 			if (plugin.Scp914KnobChange)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.scp914knobchange} {ev.KnobSetting}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.scp914knobchange} {ev.KnobSetting}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerEnterFemur (FemurEnterEvent ev)
 		{
+			if (plugin.EmoteLogs)
+				emote = ":skull: ";
+
 			if (plugin.EnterFemur)
-				ProcessSTT.SendData($"{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasEnteredFemur}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.hasEnteredFemur}.", HandleQueue.GameLogChannelId);
 		}
 	}
 }

--- a/DiscordIntegration/EventHandlers.cs
+++ b/DiscordIntegration/EventHandlers.cs
@@ -259,8 +259,10 @@ namespace DiscordIntegration_Plugin
 			if (plugin.EmoteLogs)
 				emote = ":no_entry: ";
 
+			DateTime dt = new DateTime(ev.Details.Expires).ToLocalTime();
+
 			if (plugin.Banned)
-				ProcessSTT.SendData($"{emote}{ev.Details.OriginalName} - {ev.Details.Id} {Plugin.translation.wasBannedBy} {ev.Details.Issuer} {Plugin.translation._for} {ev.Details.Reason}. {DateTime.Now.AddTicks(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
+				ProcessSTT.SendData($"{emote}{ev.Details.OriginalName} - {ev.Details.Id} {Plugin.translation.wasBannedBy} {ev.Details.Issuer} {Plugin.translation._for} {ev.Details.Reason}. Expires: {dt.ToString("MM/dd/yy hh:mm tt")}", HandleQueue.CommandLogChannelId);
 		}
 
 		public void OnIntercomSpeak(ref IntercomSpeakEvent ev)

--- a/DiscordIntegration/EventHandlers.cs
+++ b/DiscordIntegration/EventHandlers.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using EXILED;
-using GameCore;
+using EXILED.Extensions;
 using Grenades;
 using MEC;
 using Scp914;
@@ -23,7 +23,7 @@ namespace DiscordIntegration_Plugin
 			{
 				ev.Allow = false;
 				string message = "";
-				foreach (ReferenceHub hub in Plugin.GetHubs())
+				foreach (ReferenceHub hub in Player.GetHubs())
 					message +=
 						$"{hub.nicknameSync.MyNick} - ({hub.characterClassManager.UserId})\n";
 				if (string.IsNullOrEmpty(message))
@@ -33,7 +33,7 @@ namespace DiscordIntegration_Plugin
 			else if (ev.Command.ToLower() == "stafflist")
 			{
 				ev.Allow = false;
-				Plugin.Info("Staff listen");
+				Log.Info("Staff listen");
 				bool isStaff = false;
 				string names = "";
 				foreach (GameObject o in PlayerManager.players)
@@ -47,7 +47,7 @@ namespace DiscordIntegration_Plugin
 					}
 				}
 
-				Plugin.Info($"Bool: {isStaff} Names: {names}");
+				Log.Info($"Bool: {isStaff} Names: {names}");
 				string response = isStaff ? names : $"{Plugin.translation.noStaffOnline}";
 				ev.Sender.RAMessage($"{PlayerManager.players.Count}/25 {response}");
 			}
@@ -83,7 +83,7 @@ namespace DiscordIntegration_Plugin
 			{
 				try
 				{
-					if (ev.Attacker != null && ev.Attacker.characterClassManager != null && Plugin.GetTeam(ev.Player.characterClassManager.CurClass) == Plugin.GetTeam(ev.Attacker.characterClassManager.CurClass) && ev.Player != ev.Attacker)
+					if (ev.Attacker != null && ev.Attacker.characterClassManager != null && Player.GetTeam(ev.Player.characterClassManager.CurClass) == Player.GetTeam(ev.Attacker.characterClassManager.CurClass) && ev.Player != ev.Attacker)
 						ProcessSTT.SendData(
 							$"**{ev.Attacker.nicknameSync.MyNick} - {ev.Attacker.characterClassManager.UserId} ({ev.Attacker.characterClassManager.CurClass}) {Plugin.translation.damaged} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation._for} {ev.Info.Amount} {Plugin.translation.with} {ev.Info.Tool}.**",
 							HandleQueue.GameLogChannelId);
@@ -96,7 +96,7 @@ namespace DiscordIntegration_Plugin
 				}
 				catch (Exception e)
 				{
-					Plugin.Error($"Player Hurt error: {e}");
+					Log.Error($"Player Hurt error: {e}");
 				}
 			}
 		}
@@ -107,7 +107,7 @@ namespace DiscordIntegration_Plugin
 			{
 				try
 				{
-					if (ev.Killer != null && ev.Killer.characterClassManager != null && Plugin.GetTeam(ev.Player.characterClassManager.CurClass) == Plugin.GetTeam(ev.Killer.characterClassManager.CurClass))
+					if (ev.Killer != null && ev.Killer.characterClassManager != null && Player.GetTeam(ev.Player.characterClassManager.CurClass) == Player.GetTeam(ev.Killer.characterClassManager.CurClass))
 						ProcessSTT.SendData(
 							$"**{ev.Killer.nicknameSync.MyNick} - {ev.Killer.characterClassManager.UserId} ({ev.Killer.characterClassManager.CurClass}) {Plugin.translation.killed} {ev.Player.nicknameSync.MyNick} - {ev.Player.characterClassManager.UserId} ({ev.Player.characterClassManager.CurClass}) {Plugin.translation.with} {ev.Info.Tool}.**",
 							HandleQueue.GameLogChannelId);
@@ -120,7 +120,7 @@ namespace DiscordIntegration_Plugin
 				}
 				catch (Exception e)
 				{
-					Plugin.Error($"Player Hurt error: {e}");
+					Log.Error($"Player Hurt error: {e}");
 				}
 			}
 		}

--- a/DiscordIntegration/EventHandlers.cs
+++ b/DiscordIntegration/EventHandlers.cs
@@ -77,8 +77,16 @@ namespace DiscordIntegration_Plugin
 
 		public void OnRoundEnd()
 		{
+			int min = RoundSummary.roundTime / 60;
+			int sec = RoundSummary.roundTime % 60;
+
 			if (plugin.RoundEnd)
-				ProcessSTT.SendData($"{emote}{Plugin.translation.roundEnded}: {Plugin.GetHubs().Count} {Plugin.translation.playersOnline}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($"{emote}***{Plugin.translation.roundEnded}.***\n" +
+					$"```Round Time: {min}:{sec}\n" +
+					$"Escaped D-Class: {RoundSummary.escaped_ds}\n" +
+					$"Escaped Scientists: {RoundSummary.escaped_scientists}\n" +
+					$"Kills by SCPs: {RoundSummary.kills_by_scp}\n```",
+					HandleQueue.GameLogChannelId);
 		}
 
 		public void OnCheaterReport(ref CheaterReportEvent ev)

--- a/DiscordIntegration/Integration/HandleQueue.cs
+++ b/DiscordIntegration/Integration/HandleQueue.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MEC;
+using Log = EXILED.Log;
 
 namespace DiscordIntegration_Plugin
 {
@@ -16,12 +17,12 @@ namespace DiscordIntegration_Plugin
 			while (ProcessSTT.dataQueue.TryDequeue(out SerializedData.SerializedData result))
 			{
 				string command = result.Data;
-				Plugin.Debug($"STT: Received {result.Data} for {result.Port} at {result.Channel}");
+				Log.Debug($"STT: Received {result.Data} for {result.Port} at {result.Channel}");
 				
 				
 				if (result.Data == "ping")
 				{
-					Plugin.Debug("STT: Heartbeat received.");
+					Log.Debug("STT: Heartbeat received.");
 					ProcessSTT.SendData("ping", 0);
 					return;
 				}
@@ -29,14 +30,14 @@ namespace DiscordIntegration_Plugin
 				if (result.Data == "set gameid")
 				{
 					GameLogChannelId = result.Channel;
-					Plugin.Debug($"STT: GameLogChannelId changed: {result.Channel}");
+					Log.Debug($"STT: GameLogChannelId changed: {result.Channel}");
 					return;
 				}
 
 				if (result.Data == "set cmdid")
 				{
 					CommandLogChannelId = result.Channel;
-					Plugin.Debug($"STT: CommandLogChannelId changed: {result.Channel}");
+					Log.Debug($"STT: CommandLogChannelId changed: {result.Channel}");
 					return;
 				}
 
@@ -55,7 +56,7 @@ namespace DiscordIntegration_Plugin
 				}
 				catch (Exception e)
 				{
-					Plugin.Error(e.ToString());
+					Log.Error(e.ToString());
 				}
 			}
 		}
@@ -71,7 +72,7 @@ namespace DiscordIntegration_Plugin
 				}
 				catch (Exception e)
 				{
-					Plugin.Error($"STT: Error handling queue. {e}");
+					Log.Error($"STT: Error handling queue. {e}");
 				}
 
 				yield return Timing.WaitForSeconds(1f);

--- a/DiscordIntegration/Integration/ProcessSTT.cs
+++ b/DiscordIntegration/Integration/ProcessSTT.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
+using Log = EXILED.Log;
 
 namespace DiscordIntegration_Plugin
 {
@@ -22,12 +23,12 @@ namespace DiscordIntegration_Plugin
 			Thread.Sleep(1000);
 			try
 			{
-				Plugin.Info($"STT: Starting INIT for {ServerConsole.Port}");
+				Log.Info($"STT: Starting INIT for {ServerConsole.Port}");
 				tcpClient?.Close();
 				tcpClient = new TcpClient();
 				while (!tcpClient.Connected)
 				{
-					Plugin.Debug($"STT: While loop start");
+					Log.Debug($"STT: While loop start");
 					Thread.Sleep(2000);
 					try
 					{
@@ -42,7 +43,7 @@ namespace DiscordIntegration_Plugin
 					}
 					catch (Exception e)
 					{
-						Plugin.Error($"STT: {e}");
+						Log.Error($"STT: {e}");
 					}
 				}
 
@@ -66,7 +67,7 @@ namespace DiscordIntegration_Plugin
 			catch (Exception e)
 			{
 				_locked = false;
-				Plugin.Error(e.ToString());
+				Log.Error(e.ToString());
 			}
 		}
 
@@ -88,7 +89,7 @@ namespace DiscordIntegration_Plugin
 					};
 				BinaryFormatter formatter = new BinaryFormatter();
 				formatter.Serialize(tcpClient.GetStream(), serializedData);
-				Plugin.Debug($"Sent {data}");
+				Log.Debug($"Sent {data}");
 			}
 			catch (IOException)
 			{
@@ -97,7 +98,7 @@ namespace DiscordIntegration_Plugin
 			}
 			catch (Exception e)
 			{
-				Plugin.Error(e.ToString());
+				Log.Error(e.ToString());
 			}
 		}
 
@@ -129,7 +130,7 @@ namespace DiscordIntegration_Plugin
 			}
 			catch (Exception e)
 			{
-				Plugin.Error(e.ToString());
+				Log.Error(e.ToString());
 			}
 		}
 	}

--- a/DiscordIntegration/Methods.cs
+++ b/DiscordIntegration/Methods.cs
@@ -1,3 +1,6 @@
+using EXILED.Extensions;
+using Log = EXILED.Log;
+
 namespace DiscordIntegration_Plugin
 {
 	public class Methods
@@ -7,28 +10,28 @@ namespace DiscordIntegration_Plugin
 
 		public static void CheckForSyncRole(ReferenceHub player)
 		{
-			Plugin.Info($"Checking rolesync for {player.characterClassManager.UserId}");
+			Log.Info($"Checking rolesync for {player.characterClassManager.UserId}");
 			ProcessSTT.SendData($"checksync {player.characterClassManager.UserId}", 119);
 		}
 
 		public static void SetSyncRole(string group, string steamId)
 		{
-			Plugin.Info($"Received setgroup for {steamId}");
+			Log.Info($"Received setgroup for {steamId}");
 			UserGroup userGroup = ServerStatic.PermissionsHandler.GetGroup(group);
 			if (userGroup == null)
 			{
-				Plugin.Error($"Attempted to assign invalid user group {group} to {steamId}");
+				Log.Error($"Attempted to assign invalid user group {group} to {steamId}");
 				return;
 			}
 
-			ReferenceHub player = Plugin.GetPlayer(steamId);
+			ReferenceHub player = Player.GetPlayer(steamId);
 			if (player == null)
 			{
-				Plugin.Error($"Error assigning user group to {steamId}, player not found.");
+				Log.Error($"Error assigning user group to {steamId}, player not found.");
 				return;
 			}
 			
-			Plugin.Info($"Assigning role: {userGroup} to {steamId}.");
+			Log.Info($"Assigning role: {userGroup} to {steamId}.");
 			player.serverRoles.SetGroup(userGroup, false);
 		}
 	}

--- a/DiscordIntegration/Plugin.cs
+++ b/DiscordIntegration/Plugin.cs
@@ -50,6 +50,7 @@ namespace DiscordIntegration_Plugin
 		public static string EggAddress = "";
 		public bool OnlyFriendlyFire = true;
 		public bool RoleSync = true;
+		public bool EmoteLogs = false;
 		
 		public override void OnEnable()
 		{
@@ -181,6 +182,7 @@ namespace DiscordIntegration_Plugin
 			EggAddress = Config.GetString("discord_ip_address", string.Empty);
 			OnlyFriendlyFire = Config.GetBool("discord_only_ff", true);
 			RoleSync = Config.GetBool("discord_rolesync", true);
+			EmoteLogs = Config.GetBool("discord_emote_logs", false);
 		}
 
 		public static Translation translation = new Translation();

--- a/DiscordIntegration/Plugin.cs
+++ b/DiscordIntegration/Plugin.cs
@@ -38,7 +38,7 @@ namespace DiscordIntegration_Plugin
 		public bool Decon = true;
 		public bool DropItem = true;
 		public bool PickupItem = true;
-		public bool Intercom = true;
+		public bool Intercom = false;
 		public bool Banned = true;
 		public bool Cuffed = true;
 		public bool Freed = true;
@@ -172,6 +172,7 @@ namespace DiscordIntegration_Plugin
 			Decon = Config.GetBool("discord_decon", true);
 			DropItem = Config.GetBool("discord_item_drop", true);
 			PickupItem = Config.GetBool("discord_item_pickup", true);
+			Intercom = Config.GetBool("discord_intercom", false);
 			Banned = Config.GetBool("discord_banned", true);
 			Cuffed = Config.GetBool("discord_cuffed", true);
 			Freed = Config.GetBool("discord_freed", true);

--- a/DiscordIntegration/Plugin.cs
+++ b/DiscordIntegration/Plugin.cs
@@ -7,6 +7,7 @@ using GameCore;
 using MEC;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Log = EXILED.Log;
 
 namespace DiscordIntegration_Plugin
 {
@@ -209,8 +210,8 @@ namespace DiscordIntegration_Plugin
 			}
 			catch (Exception e)
 			{
-				Info("Invalid or corrupted translation file, creating backup and overwriting.");
-				Error(e.Message);
+				Log.Info("Invalid or corrupted translation file, creating backup and overwriting.");
+				Log.Error(e.Message);
 
 				string json = JObject.FromObject(translation).ToString();
 
@@ -229,8 +230,8 @@ namespace DiscordIntegration_Plugin
 			}
 			catch (Exception e)
 			{
-				Info("Invalid or corrupted translation file, creating backup and overwriting.");
-				Error(e.Message);
+				Log.Info("Invalid or corrupted translation file, creating backup and overwriting.");
+				Log.Error(e.Message);
 				refreshTranslationFile = true;
 			}
 
@@ -238,7 +239,7 @@ namespace DiscordIntegration_Plugin
 			{
 				string json = JObject.FromObject(translation).ToString();
 
-				Info("Invalid or missing translation element detected fixing: " + string.Join(", ", propertyNames) + ".");
+				Log.Info("Invalid or missing translation element detected fixing: " + string.Join(", ", propertyNames) + ".");
 
 				File.Copy(translationFileName, translationBackupFileName, true);
 

--- a/DiscordIntegration/Plugin.cs
+++ b/DiscordIntegration/Plugin.cs
@@ -27,6 +27,7 @@ namespace DiscordIntegration_Plugin
 		public bool SetClass = true;
 		public bool Respawn = true;
 		public bool PlayerJoin = true;
+		public bool PlayerLeave = true;
 		public bool DoorInteract = true;
 		public bool Scp914Upgrade = true;
 		public bool Scp079Tesla = true;
@@ -43,6 +44,7 @@ namespace DiscordIntegration_Plugin
 		public bool Freed = true;
 		public bool Scp914Activation = true;
 		public bool Scp914KnobChange = true;
+		public bool EnterFemur = true;
 		
 		public static bool Egg = false;
 		public static string EggAddress = "";
@@ -65,7 +67,7 @@ namespace DiscordIntegration_Plugin
 			Events.SetClassEvent += EventHandlers.OnSetClass;
 			Events.TeamRespawnEvent += EventHandlers.OnRespawn;
 			Events.PlayerJoinEvent += EventHandlers.OnPlayerJoin;
-			
+			Events.PlayerLeaveEvent += EventHandlers.OnPlayerLeave;
 			Events.DoorInteractEvent += EventHandlers.OnDoorInteract;
 			Events.Scp914UpgradeEvent += EventHandlers.OnScp194Upgrade;
 			Events.Scp079TriggerTeslaEvent += EventHandlers.On079Tesla;
@@ -82,6 +84,7 @@ namespace DiscordIntegration_Plugin
 			Events.PlayerHandcuffFreedEvent += EventHandlers.OnPlayerFreed;
 			Events.Scp914ActivationEvent += EventHandlers.On914Activation;
 			Events.Scp914KnobChangeEvent += EventHandlers.On914KnobChange;
+			Events.FemurEnterEvent += EventHandlers.OnPlayerEnterFemur;
 
 			LoadTranslation();
 
@@ -104,6 +107,7 @@ namespace DiscordIntegration_Plugin
 			Events.SetClassEvent -= EventHandlers.OnSetClass;
 			Events.TeamRespawnEvent -= EventHandlers.OnRespawn;
 			Events.PlayerJoinEvent -= EventHandlers.OnPlayerJoin;
+			Events.PlayerLeaveEvent -= EventHandlers.OnPlayerLeave;
 			Events.DoorInteractEvent -= EventHandlers.OnDoorInteract;
 			Events.Scp914UpgradeEvent -= EventHandlers.OnScp194Upgrade;
 			Events.Scp079TriggerTeslaEvent -= EventHandlers.On079Tesla;
@@ -120,6 +124,7 @@ namespace DiscordIntegration_Plugin
 			Events.PlayerHandcuffFreedEvent -= EventHandlers.OnPlayerFreed;
 			Events.Scp914ActivationEvent -= EventHandlers.On914Activation;
 			Events.Scp914KnobChangeEvent -= EventHandlers.On914KnobChange;
+			Events.FemurEnterEvent -= EventHandlers.OnPlayerEnterFemur;
 			EventHandlers = null;
 			Timing.KillCoroutines("handle");
 			Timing.KillCoroutines("update");
@@ -155,6 +160,7 @@ namespace DiscordIntegration_Plugin
 			SetClass = Config.GetBool("discord_set_class", true);
 			Respawn = Config.GetBool("discord_respawn", true);
 			PlayerJoin = Config.GetBool("discord_player_join", true);
+			PlayerLeave = Config.GetBool("discord_player_leave", true);
 			DoorInteract = Config.GetBool("discord_doorinteract", false);
 			Scp914Upgrade = Config.GetBool("discord_914upgrade", true);
 			Scp079Tesla = Config.GetBool("discord_079tesla", true);
@@ -170,6 +176,7 @@ namespace DiscordIntegration_Plugin
 			Freed = Config.GetBool("discord_freed", true);
 			Scp914Activation = Config.GetBool("discord_914_activation", true);
 			Scp914KnobChange = Config.GetBool("discord_914_knob", true);
+			EnterFemur = Config.GetBool("discord_enter_femur", true);
 			Egg = Config.GetBool("discord_egg_mode", false);
 			EggAddress = Config.GetString("discord_ip_address", string.Empty);
 			OnlyFriendlyFire = Config.GetBool("discord_only_ff", true);
@@ -284,6 +291,7 @@ namespace DiscordIntegration_Plugin
 		public string hasSpawnedWith = "has spawned with";
 		public string players = "players";
 		public string hasJoinedTheGame = "has joined the game";
+		public string hasLeftTheGame = "has left the game";
 		public string hasBeenFreedBy = "has been freed by";
 		public string hasBeenHandcuffedBy = "has been handcuffed by";
 		public string wasBannedBy = "was banned by";
@@ -302,5 +310,6 @@ namespace DiscordIntegration_Plugin
 		public string hasOpenedADoor = "has opened a door";
 		public string scp914HasBeenActivated = "has activated SCP-914 on setting";
 		public string scp914knobchange = "has changed the SCP-914 knob to";
+		public string hasEnteredFemur = "has entered the femur breaker";
 	}
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # DiscordIntegration
 
+**Currently using: EXILED 1.7.12** 
+
 ***Requires EXILED_Events to be installed***
+
 A bot and server plugin to allow server logs to be sent to Discord channels, and for server commands to be run via the discord bot.
 
 Installation:
 1. Extract the Plugin.dll and the bot.zip archive from the initial archive.
 2. Place the plugin dll inside the EXILED "Plugins" folder like any other plugin.
-3. Place the included "SerializedData.dll" file in "Plugins/dependenciies".
+3. Place the included "SerializedData.dll" & "Newtonsoft.Json.dll" files in "Plugins/dependencies".
 4. Extract the included bot.zip archive, then edit the "IntegrationBotConfig.json" file.
         4a. In this file, you will need to enter your preferred Prefix, the token for the Discord bot to use, the ID of the channel you want RA commands to be logged to, and the channel to log everything else to. If you want to allow people to run commands via the bot, you need to add the command to the "AllowedCommands" list, and assign it a required permission level to be used, like so ``"AllowedCommands":{"list":0, "command":1, "anothercommand":3}`` etc.. Note that only the command name needs to be present, not it's arguments. IE: "bc" would allow people to run "bc 10 hello".
 
@@ -14,7 +17,8 @@ In the above example, anyone can run the command "list", people with permission 
 
 To setup permission levels, simply enter the ID of the role you want to receive a specific permission level in the appropriate config field for the desired permission level. Note, that currently each permission level supports a single RoleID only, if a user has more than one role granting them a permission level, the highest level will be used. A user with no roles that grant permission level, will have a permission level of 0.
 
-```Bot Config```
+**Bot Config**
+
 Default values and explination:
 Bot Prefix: ! - the prefix used before bot commands to tell the bot you want it to do something, alternatively, you can @ the bot instead.
 
@@ -36,20 +40,46 @@ GameLogChannelId: 0 - the ChannelId where the bot will log everything else that 
 
 AllowedCommands: {} - the dictionary of "command":PermissionLevelRequired commands that you want the bot to be able to run on the SCP server.
 
-```Plugin Config```
-All values go in EXILED/ServerPort-config.yml and are specific to the server to which the config file belongs to.
+**Plugin Config**
 
-discord_ra_commands: true - logs use of RA commands (even those run through the bot) to the CommandLogChannel.
-discord_round_start: true - will log when a new round starts.
-discord_waiting_for_players: true - will log when the server has generated a new map and is ready for new players to connect.
-discord_cheater_report: true - will log whenever a cheater report is filed on the server.
-discord_player_hurt: true - will log all instances of a player taking damage from any source. Friendly Fire damage will be in Bold.
-discord_player_death: true - will log all instances of a player dieing from any source. Teamkills will be in Bold.
-discord_grenade_thrown: true - will log when a player throws any type of grenade.
-discord_medical_item: true - will log when a player uses a medical item.
-discord_set_class: true - will log everytime a players in-game class/role is changed.
-discord_respawn: true - will log when server respawns occur.
-discord_player_join: true - will log when a player joins the server.
+All values go in EXILED/ServerPort-config.yml and are specific to the server to which the config file belongs to.
 
 Unless otherwise stated, all logs are sent to the "GameLogChannel" defined by the bot's config.
 To disable logging for any particular event, simply change it's value to false, and it will be ignored.
+
+Config Option | Default Value | Description
+--- | :---: | :------:
+discord_ra_commands | true | Logs use of RA commands (even those run through the bot). *Sent to the CommandLogChannel*.
+discord_round_start | true | When a new round starts.
+discord_round_end | true | When a round has ended. Will also display a round summary.
+discord_waiting_for_players | true | When the server has generated a new map and is ready for new players to connect.
+discord_cheater_report | true | Logs whenever a cheater report is filed on the server.
+discord_player_hurt | true | Logs all instances of a player taking damage from any source. Friendly Fire damage will be in Bold.
+discord_player_death | true | Logs log all instances of a player dieing from any source. Teamkills will be in Bold.
+discord_grenade_thrown | true | When a player throws any type of grenade.
+discord_medical_item | true | When a player uses a medical item.
+discord_set_class | true | Logs everytime a players in-game class/role is changed.
+discord_respawn | true | Logs when a server respawns occur (MTF/Chaos Insurgency).
+discord_player_join | true | When a player joins the server.
+discord_player_leave | true | When a player has left the server.
+discord_914upgrade | true | Displays what players and items are being upgraded in 914.
+discord_079tesla | true | When 079 fires the tesla. *May not be functional*.
+discord_106teleport | false | When 106 teleports using their portal.
+discord_penter | true | When a player is captured and set to the pocket dimension
+discord_pescape | true | When a player escapes the pocket dimension.
+discord_player_console | true | Logs when a player uses their console and what they entered. **Not for remote admin (RA), see discord_ra_commands**.
+discord_decon | true | Logs when decontamination has begun.
+discord_item_drop | true | When an item is dropped up a player.
+discord_item_pickup | true | When a item is picked up by a player.
+discord_intercom | false | Display who is using the intercom. *Caution: May spam logs*
+discord_banned | true | Logs when a player has been banned from the server, the reason, and expiration based on the server's local time.
+discord_cuffed | true | When a player has been handcuffed by another player.
+discord_freed | true | When a player previously handcuffed has been freed.
+discord_914_activation | true | When SCP 914 is activated, showing who activated it, their class, and what setting it was on when they activated it.
+discord_914_knob | true | When SCP-914's knob setting is changed, showing who changed it, their class and what the new knob setting is.
+discord_enter_femur | true | When a player sacrifies themselves to the femur breaker.
+discord_only_ff | true | Will only send player_hurt and player_death events if it was friendly fire.
+discord_rolesync | true | Will enable the rolesync function of the bot. [Click here for details](https://github.com/galaxy119/DiscordIntegration/releases/tag/1.1.0)
+discord_emote_logs | false | Will display emotes next to individual events for readability. **You must enable to use**.
+
+Sample config file: https://pastebin.com/44bmh2Vf


### PR DESCRIPTION
* Updated to EXILED 1.7.12

+ PlayerLeaveEvent & FemurEnterEvent added
+ Emotes next to individual logged events (similar to SCPDiscord), defaults to false
+ OnRoundEnd now displays a round summary.
+ OnPlayerBanned now shows readable expiration time/date based on machine's local time
+ OnPlayerHurt & OnPlayerDeath shows description of what hurt/killed instead of numbers
+ Inserted missing config for IntercomSpeakEvent.
+ Major README overhaul
* Replaced MOST (left 1) obsolete methods
* "Dedicated Server" no longer shows with OnSetClass
* Corrected player count for OnRoundStart
* Due to history of spam, _discord_intercom_ defaults to false

-RDSparkle