### PR TITLE
Formatting and Argument changes

### DIFF
--- a/DiscordIntegration/MapEvents.cs
+++ b/DiscordIntegration/MapEvents.cs
@@ -11,7 +11,7 @@ namespace DiscordIntegration_Plugin
         public void OnWarheadDetonation()
         {
             if (Plugin.Singleton.Config.WarheadDetonate)
-                ProcessSTT.SendData($"{Plugin.translation.WarheadDetonated}.", HandleQueue.GameLogChannelId);
+                ProcessSTT.SendData($":radioactive: **{Plugin.translation.WarheadDetonated}.**", HandleQueue.GameLogChannelId);
         }
 
 
@@ -24,19 +24,19 @@ namespace DiscordIntegration_Plugin
         public void OnDecon(DecontaminatingEventArgs ev)
         {
             if (Plugin.Singleton.Config.Decon)
-                ProcessSTT.SendData($"{Plugin.translation.HasDropped}.", HandleQueue.CommandLogChannelId);
+                ProcessSTT.SendData($":biohazard: **{Plugin.translation.DecontaminationHasBegun}.**", HandleQueue.GameLogChannelId);
         }
         
         public void OnWarheadStart(StartingEventArgs ev)
         {
             if (Plugin.Singleton.Config.WarheadStart)
-                ProcessSTT.SendData($"{Plugin.translation.WarheadStarted} {Warhead.Controller.NetworktimeToDetonation}.", HandleQueue.GameLogChannelId);
+                ProcessSTT.SendData($":biohazard: **{Plugin.translation.WarheadStarted} {Warhead.Controller.NetworktimeToDetonation} seconds.**", HandleQueue.GameLogChannelId);
         }
         
         public void OnWarheadCancelled(StoppingEventArgs ev)
         {
             if (Plugin.Singleton.Config.WarheadCancel)
-                ProcessSTT.SendData($"{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.CancelledWarhead}.", HandleQueue.GameLogChannelId);
+                ProcessSTT.SendData($"***{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.CancelledWarhead}.***", HandleQueue.GameLogChannelId);
         }
         
         public void OnScp194Upgrade(UpgradingItemsEventArgs ev)

--- a/DiscordIntegration/MapEvents.cs
+++ b/DiscordIntegration/MapEvents.cs
@@ -30,7 +30,7 @@ namespace DiscordIntegration_Plugin
         public void OnWarheadStart(StartingEventArgs ev)
         {
             if (Plugin.Singleton.Config.WarheadStart)
-                ProcessSTT.SendData($":biohazard: **{Plugin.translation.WarheadStarted} {Warhead.Controller.NetworktimeToDetonation} seconds.**", HandleQueue.GameLogChannelId);
+                ProcessSTT.SendData($":radioactive: **{Plugin.translation.WarheadStarted} {Warhead.Controller.NetworktimeToDetonation} seconds.**", HandleQueue.GameLogChannelId);
         }
         
         public void OnWarheadCancelled(StoppingEventArgs ev)

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -63,7 +63,7 @@ namespace DiscordIntegration_Plugin
 		public void OnPlayerLeave(LeftEventArgs ev)
 		{
 			if (Plugin.Singleton.Config.PlayerLeave)
-				ProcessSTT.SendData($":arrow_left:{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.LeftServer}", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($":arrow_left: **{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.LeftServer}.**", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerReload(ReloadingWeaponEventArgs ev)
@@ -153,7 +153,7 @@ namespace DiscordIntegration_Plugin
 		public void On079Tesla(InteractingTeslaEventArgs ev)
 		{
 			if (Plugin.Singleton.Config.Scp079Tesla)
-				ProcessSTT.SendData($":zap:{ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.HasTriggeredATeslaGate}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($":zap: {ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.HasTriggeredATeslaGate}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerHurt(HurtingEventArgs ev)
@@ -188,7 +188,7 @@ namespace DiscordIntegration_Plugin
 				{
 					if (ev.Killer != null && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam())
 						ProcessSTT.SendData(
-							$":skull_crossbones:**{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformations.Tool).name}.**",
+							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformations.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
 					{
@@ -210,7 +210,7 @@ namespace DiscordIntegration_Plugin
 			{
 				if (ev.Player == null)
 					return;
-				ProcessSTT.SendData($":bomb:{ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.ThrewAGrenade}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($":bomb: {ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.ThrewAGrenade}.", HandleQueue.GameLogChannelId);
 			}
 		}
 
@@ -220,7 +220,7 @@ namespace DiscordIntegration_Plugin
 			{
 				if (ev.Player == null)
 					return;
-				ProcessSTT.SendData($":medical_symbol:{ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.UsedA} {ev.Item}", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($":medical_symbol: {ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.UsedA} {ev.Item}", HandleQueue.GameLogChannelId);
 			}
 		}
 
@@ -240,14 +240,14 @@ namespace DiscordIntegration_Plugin
 				Methods.CheckForSyncRole(ev.Player);
 			if (Plugin.Singleton.Config.PlayerJoin)
 				if (ev.Player.Nickname != "Dedicated Server")
-					ProcessSTT.SendData($":arrow_right:{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.HasJoinedTheGame}.", HandleQueue.GameLogChannelId);
+					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} ||({ev.Player.IPAddress})|| {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerFreed(RemovingHandcuffsEventArgs ev)
 		{
 			if (Plugin.Singleton.Config.Freed)
 				ProcessSTT.SendData(
-					$":unlock:{ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.HasBeenFreedBy} {ev.Cuffer.Nickname} - {ev.Cuffer.UserId} ({ev.Cuffer.Role})",
+					$":unlock: {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.HasBeenFreedBy} {ev.Cuffer.Nickname} - {ev.Cuffer.UserId} ({ev.Cuffer.Role})",
 						HandleQueue.GameLogChannelId);
 		}
 
@@ -255,20 +255,20 @@ namespace DiscordIntegration_Plugin
 		{
 			if (Plugin.Singleton.Config.Cuffed)
 				ProcessSTT.SendData(
-					$":lock:{ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.HasBeenHandcuffedBy} {ev.Cuffer.Nickname} - {ev.Cuffer.UserId} ({ev.Cuffer.Role})",
+					$":lock: {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.HasBeenHandcuffedBy} {ev.Cuffer.Nickname} - {ev.Cuffer.UserId} ({ev.Cuffer.Role})",
 						HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerBanned(BannedEventArgs ev)
 		{
 			if (Plugin.Singleton.Config.Banned)
-				ProcessSTT.SendData($":no_entry:{ev.Details.OriginalName} - {ev.Details.Id} {Plugin.translation.WasBannedBy} {ev.Details.Issuer} {Plugin.translation._For} {ev.Details.Reason}. {new DateTime(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
+				ProcessSTT.SendData($":no_entry: {ev.Details.OriginalName} - {ev.Details.Id} {Plugin.translation.WasBannedBy} {ev.Details.Issuer} {Plugin.translation._For} {ev.Details.Reason}. {new DateTime(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
 		}
 
 		public void OnIntercomSpeak(IntercomSpeakingEventArgs ev)
 		{
 			if (Plugin.Singleton.Config.Intercom)
-				ProcessSTT.SendData($":sound_loud:{ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.HasStartedUsingTheIntercom}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($":loud_sound: {ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.HasStartedUsingTheIntercom}.", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPickupItem(PickingUpItemEventArgs ev)
@@ -289,7 +289,7 @@ namespace DiscordIntegration_Plugin
 			{
 				if (Plugin.Singleton.Config.SetGroup)
 					ProcessSTT.SendData(
-						$"{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.GroupSet}: {ev.NewGroup.BadgeText} ({ev.NewGroup.BadgeColor}).",
+						$"{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.GroupSet}: **{ev.NewGroup.BadgeText} ({ev.NewGroup.BadgeColor})**.",
 						HandleQueue.GameLogChannelId);
 			}
 			catch (Exception e)

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -188,7 +188,7 @@ namespace DiscordIntegration_Plugin
 				{
 					if (ev.Killer != null && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam())
 						ProcessSTT.SendData(
-							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) __team-killed__ {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
+							$":o: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
 					{

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -240,7 +240,7 @@ namespace DiscordIntegration_Plugin
 				Methods.CheckForSyncRole(ev.Player);
 			if (Plugin.Singleton.Config.PlayerJoin)
 				if (ev.Player.Nickname != "Dedicated Server")
-					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} ||({ev.Player.IPAddress})|| {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
+					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
 		}
 
 		public void OnPlayerFreed(RemovingHandcuffsEventArgs ev)

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -186,14 +186,14 @@ namespace DiscordIntegration_Plugin
 			{
 				try
 				{
-					if (ev.Killer != null)
+					if (ev.Killer != null && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam())
 						ProcessSTT.SendData(
-							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
+							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) __team-killed__ {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
 					{
 						ProcessSTT.SendData(
-							$"{ev.HitInformation.Attacker} {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.",
+							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					}
 				}

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -164,7 +164,7 @@ namespace DiscordIntegration_Plugin
 				{
 					if (ev.Attacker != null && ev.Target.Role.GetTeam() == ev.Attacker.Role.GetTeam() && ev.Target != ev.Attacker)
 						ProcessSTT.SendData(
-							$"**{ev.Attacker.Nickname} - {ev.Attacker.UserId} ({ev.Attacker.Role}) {Plugin.translation.Damaged} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation._For} {ev.Amount} {Plugin.translation.With} {DamageTypes.FromIndex(ev.Tool).name}.**",
+							$":crossed_swords: **{ev.Attacker.Nickname} - {ev.Attacker.UserId} ({ev.Attacker.Role}) {Plugin.translation.Damaged} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation._For} {ev.Amount} {Plugin.translation.With} {DamageTypes.FromIndex(ev.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
 					{
@@ -180,20 +180,20 @@ namespace DiscordIntegration_Plugin
 			}
 		}
 		
-		public void OnPlayerDeath(DiedEventArgs ev)
+		public void OnPlayerDeath(DyingEventArgs ev)
 		{
 			if (Plugin.Singleton.Config.PlayerDeath)
 			{
 				try
 				{
-					if (ev.Killer != null && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam())
+					if (ev.Killer != null)
 						ProcessSTT.SendData(
-							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformations.Tool).name}.**",
+							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
 					{
 						ProcessSTT.SendData(
-							$"{ev.HitInformations.Attacker} {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformations.Tool).name}.",
+							$"{ev.HitInformation.Attacker} {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.",
 							HandleQueue.GameLogChannelId);
 					}
 				}

--- a/DiscordIntegration/ServerEvents.cs
+++ b/DiscordIntegration/ServerEvents.cs
@@ -13,7 +13,7 @@ namespace DiscordIntegration_Plugin
         public void OnCommand(SendingRemoteAdminCommandEventArgs ev)
         {
             if (Plugin.Singleton.Config.RaCommands)
-                ProcessSTT.SendData($"{ev.Sender.Nickname} {Plugin.translation.UsedCommand}: {ev.Name}", HandleQueue.CommandLogChannelId);
+                ProcessSTT.SendData($":keyboard: {ev.Sender.Nickname}({ev.Sender.UserId}) {Plugin.translation.UsedCommand}: {ev.Name}", HandleQueue.CommandLogChannelId);
             if (ev.Name.ToLower() == "list")
             {
                 Log.Info("Getting List");
@@ -51,19 +51,19 @@ namespace DiscordIntegration_Plugin
         public void OnWaitingForPlayers()
         {
             if (Plugin.Singleton.Config.WaitingForPlayers)
-                ProcessSTT.SendData($":hourglass:{Plugin.translation.WaitingForPlayers}", HandleQueue.GameLogChannelId);
+                ProcessSTT.SendData($":hourglass: {Plugin.translation.WaitingForPlayers}", HandleQueue.GameLogChannelId);
         }
 
         public void OnRoundStart()
         {
             if (Plugin.Singleton.Config.RoundStart)
-                ProcessSTT.SendData($":arrow_forward:{Plugin.translation.RoundStarting}: {Player.List.Count()} {Plugin.translation.PlayersInRound}.", HandleQueue.GameLogChannelId);
+                ProcessSTT.SendData($":arrow_forward: {Plugin.translation.RoundStarting}: {Player.List.Count()} {Plugin.translation.PlayersInRound}.", HandleQueue.GameLogChannelId);
         }
 
         public void OnRoundEnd(RoundEndedEventArgs ev)
         {
             if (Plugin.Singleton.Config.RoundEnd)
-                ProcessSTT.SendData($":stop_button:{Plugin.translation.RoundEnded}: {Player.List.Count()} {Plugin.translation.PlayersOnline}.", HandleQueue.GameLogChannelId);
+                ProcessSTT.SendData($":stop_button: {Plugin.translation.RoundEnded}: {Player.List.Count()} {Plugin.translation.PlayersOnline}.", HandleQueue.GameLogChannelId);
         }
 
         public void OnCheaterReport(ReportingCheaterEventArgs ev)

--- a/DiscordIntegration/ServerEvents.cs
+++ b/DiscordIntegration/ServerEvents.cs
@@ -75,8 +75,9 @@ namespace DiscordIntegration_Plugin
         
         public void OnConsoleCommand(SendingConsoleCommandEventArgs ev)
         {
+            string Argies = string.Join(" ", ev.Arguments);
             if (Plugin.Singleton.Config.ConsoleCommand)
-                ProcessSTT.SendData($"{ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.HasRunClientConsoleCommand}: {ev.Name}", HandleQueue.CommandLogChannelId);
+                ProcessSTT.SendData($"{ev.Player.Nickname} - {ev.Player.UserId} ({ev.Player.Role}) {Plugin.translation.HasRunClientConsoleCommand}: {ev.Name} {Argies}", HandleQueue.CommandLogChannelId);
         }
         
         public void OnRespawn(RespawningTeamEventArgs ev)

--- a/DiscordIntegration/ServerEvents.cs
+++ b/DiscordIntegration/ServerEvents.cs
@@ -12,8 +12,9 @@ namespace DiscordIntegration_Plugin
         
         public void OnCommand(SendingRemoteAdminCommandEventArgs ev)
         {
+            string Args = string.Join(" ", ev.Arguments);
             if (Plugin.Singleton.Config.RaCommands)
-                ProcessSTT.SendData($":keyboard: {ev.Sender.Nickname}({ev.Sender.UserId}) {Plugin.translation.UsedCommand}: {ev.Name}", HandleQueue.CommandLogChannelId);
+                ProcessSTT.SendData($":keyboard: {ev.Sender.Nickname}({ev.Sender.UserId}) {Plugin.translation.UsedCommand}: {ev.Name} {Args}", HandleQueue.CommandLogChannelId);
             if (ev.Name.ToLower() == "list")
             {
                 Log.Info("Getting List");
@@ -82,7 +83,7 @@ namespace DiscordIntegration_Plugin
         {
             if (Plugin.Singleton.Config.Respawn)
             {
-                string msg = ev.NextKnownTeam == SpawnableTeamType.ChaosInsurgency ? $"{Plugin.translation.ChaosInsurgency}" : $"{Plugin.translation.NineTailedFox}";
+                string msg = ev.NextKnownTeam == SpawnableTeamType.ChaosInsurgency ? $":spy: {Plugin.translation.ChaosInsurgency}" : $":cop: {Plugin.translation.NineTailedFox}";
                 ProcessSTT.SendData($"{msg} {Plugin.translation.HasSpawnedWith} {ev.Players.Count} {Plugin.translation.Players}.", HandleQueue.GameLogChannelId);
             }
         }


### PR DESCRIPTION
### Formatting
I've changed the formatting on some events to mirror their SCPDiscord counterparts and make them easier to pick out in addition to emoji prefixes. Players' IP addresses are logged in spoiler text when OnPlayerJoined is fired in the event it's needed for offline banning.
### Argument Changes
When OnCommand and OnConsoleCommand are fired, their arguments are converted from a list to a single string so that they can properly display in their respective logging channels, opposed to just the name of the command.

Needless to say, this commit is also already using DyingEventArgs with OnPlayerDeath as well.