### PR TITLE
Do Not Track flag support

### DIFF
--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -133,7 +133,7 @@ namespace DiscordIntegration_Plugin
 		{
 			if (Plugin.Singleton.Config.PocketEnter)
 				ProcessSTT.SendData(
-					$"{ev.Player.Nickname} - {ev.Player.Role} ({ev.Player.Role}) {Plugin.translation.HasEnteredPocketDimension}.",
+					$":door: {ev.Player.Nickname} - {ev.Player.Role} ({ev.Player.Role}) {Plugin.translation.HasEnteredPocketDimension}.",
 					HandleQueue.GameLogChannelId);
 		}
 
@@ -141,7 +141,7 @@ namespace DiscordIntegration_Plugin
 		{
 			if (Plugin.Singleton.Config.PocketEscape)
 				ProcessSTT.SendData(
-					$"{ev.Player.Nickname} - {ev.Player.Role} ({ev.Player.Role}) {Plugin.translation.HasEscapedPocketDimension}.",
+					$":high_brightness: {ev.Player.Nickname} - {ev.Player.Role} ({ev.Player.Role}) {Plugin.translation.HasEscapedPocketDimension}.",
 					HandleQueue.GameLogChannelId);		}
 
 		public void On106Teleport(TeleportingEventArgs ev)
@@ -230,7 +230,7 @@ namespace DiscordIntegration_Plugin
 			{
 				if (ev.Player == null)
 					return;
-				ProcessSTT.SendData($"{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.HasBenChangedToA} {ev.NewRole}.", HandleQueue.GameLogChannelId);
+				ProcessSTT.SendData($":mens: {ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.HasBenChangedToA} {ev.NewRole}.", HandleQueue.GameLogChannelId);
 			}
 		}
 
@@ -241,7 +241,7 @@ namespace DiscordIntegration_Plugin
 			if (Plugin.Singleton.Config.PlayerJoin && ev.Player.Nickname != "Dedicated Server")
 				if (!ev.Player.ReferenceHub.serverRoles.DoNotTrack)
 					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} ||({ev.Player.IPAddress})|| {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
-				else if (ev.Player.ReferenceHub.serverRoles.DoNotTrack)
+				else if (!ev.Player.ReferenceHub.serverRoles.DoNotTrack)
 					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
 		}
 

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -188,7 +188,7 @@ namespace DiscordIntegration_Plugin
 				{
 					if (ev.Killer != null && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam())
 						ProcessSTT.SendData(
-							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) __team-killed__ {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
+							$":o: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
 					{

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -241,7 +241,7 @@ namespace DiscordIntegration_Plugin
 			if (Plugin.Singleton.Config.PlayerJoin && ev.Player.Nickname != "Dedicated Server")
 				if (!ev.Player.ReferenceHub.serverRoles.DoNotTrack)
 					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} ||({ev.Player.IPAddress})|| {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
-				else if (!ev.Player.ReferenceHub.serverRoles.DoNotTrack)
+				else if (ev.Player.ReferenceHub.serverRoles.DoNotTrack)
 					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
 		}
 

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -188,7 +188,7 @@ namespace DiscordIntegration_Plugin
 				{
 					if (ev.Killer != null && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam())
 						ProcessSTT.SendData(
-							$":o: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
+							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) __team-killed__ {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
 					{
@@ -238,8 +238,10 @@ namespace DiscordIntegration_Plugin
 		{
 			if (Plugin.Singleton.Config.RoleSync)
 				Methods.CheckForSyncRole(ev.Player);
-			if (Plugin.Singleton.Config.PlayerJoin)
-				if (ev.Player.Nickname != "Dedicated Server")
+			if (Plugin.Singleton.Config.PlayerJoin && ev.Player.Nickname != "Dedicated Server")
+				if (!ev.Player.ReferenceHub.serverRoles.DoNotTrack)
+					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} ||({ev.Player.IPAddress})|| {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
+				else if (!ev.Player.ReferenceHub.serverRoles.DoNotTrack)
 					ProcessSTT.SendData($":arrow_right: **{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.translation.HasJoinedTheGame}.**", HandleQueue.GameLogChannelId);
 		}
 

--- a/DiscordIntegration/ServerEvents.cs
+++ b/DiscordIntegration/ServerEvents.cs
@@ -15,9 +15,9 @@ namespace DiscordIntegration_Plugin
             string Args = string.Join(" ", ev.Arguments);
             if (Plugin.Singleton.Config.RaCommands)
                 ProcessSTT.SendData($":keyboard: {ev.Sender.Nickname}({ev.Sender.UserId}) {Plugin.translation.UsedCommand}: {ev.Name} {Args}", HandleQueue.CommandLogChannelId);
-            if (ev.Name.ToLower() == "list")
+            if (ev.Name.ToLower() == "players")
             {
-                Log.Info("Getting List");
+                Log.Info("Fetching players...");
                 ev.IsAllowed = false;
                 string message = "";
                 foreach (Player player in Player.List)
@@ -29,9 +29,9 @@ namespace DiscordIntegration_Plugin
             }
             else if (ev.Name.ToLower() == "stafflist")
             {
-                Log.Info("Getting StaffList");
+                Log.Info("Getting Staff...");
                 ev.IsAllowed = false;
-                Log.Info("Staff list");
+                Log.Info("Staff:");
                 bool isStaff = false;
                 string names = "";
                 foreach (Player player in Player.List)

--- a/DiscordIntegration/ServerEvents.cs
+++ b/DiscordIntegration/ServerEvents.cs
@@ -15,7 +15,7 @@ namespace DiscordIntegration_Plugin
             string Args = string.Join(" ", ev.Arguments);
             if (Plugin.Singleton.Config.RaCommands)
                 ProcessSTT.SendData($":keyboard: {ev.Sender.Nickname}({ev.Sender.UserId}) {Plugin.translation.UsedCommand}: {ev.Name} {Args}", HandleQueue.CommandLogChannelId);
-            if (ev.Name.ToLower() == "players")
+            if (ev.Name.ToLower() == "list")
             {
                 Log.Info("Fetching players...");
                 ev.IsAllowed = false;


### PR DESCRIPTION
# OnPlayerJoin
I've rolled back the event to where it logged IP addresses in server logs, however this will only happen if the player does NOT have the flag active. Otherwise, the join logs will remain as they are now.
# OnPlayerDeath
Restored my version of team-kill records to support translations for public release. These are still distinguishable from regular kill logs with a red circle emoji.
# OnCommand
Some minor changes to the list commands that only affect the Log outputs; completely unnecessary and purely for some added flavor.