### PR TITLE
Some PlayerHurt/Death improvements, fix for # breaking stuff

### DIFF
--- a/DiscordIntegration/Config.cs
+++ b/DiscordIntegration/Config.cs
@@ -64,11 +64,13 @@ namespace DiscordIntegration_Plugin
         [Description("The IP address to connect to the bot, if EggMode is enabled.")]
         public string EggAddress { get; set; } = "";
         
-        [Description("Only log friendly fire for damage.")]
-        public bool OnlyFriendlyFire { get; set; } = true;
+        [Description("Only log friendly fire kills.")]
+        public bool OnlyFriendlyFire { get; set; } = false;
+        [Description("Only log friendly fire damage?")]
+        public bool OnlyFriendlyFireDMG { get; set; } = true;
         
         [Description("Wether or not the plugin should try adn set player's roles when they join based on the Discord Bot's discord sync feature.")]
-        public bool RoleSync { get; set; } = true;
+        public bool RoleSync { get; set; } = false;
         
         [Description("Wether or not the plugin is enabled.")]
         public bool IsEnabled { get; set; } = true;

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -176,7 +176,7 @@ namespace DiscordIntegration_Plugin
 						}
 						else if (!Plugin.Singleton.Config.OnlyFriendlyFireDMG)
 						{
-							if (ev.Attacker != null && ev.Target.Role.GetTeam() == ev.Attacker.Role.GetTeam() && ev.Target != ev.Attacker)
+							if (ev.Attacker != null && ev.Target != ev.Attacker && ev.Target.Role.GetTeam() == ev.Attacker.Role.GetTeam() || ev.Attacker.Role.GetSide() == ev.Target.Role.GetSide())
 							{
 								ProcessSTT.SendData($":crossed_swords: **{ev.Attacker.Nickname} - `{ev.Attacker.UserId}` ({ev.Attacker.Role}) {Plugin.Translation.Damaged} {ev.Target.Nickname} - `{ev.Target.UserId}` ({ev.Target.Role}) {Plugin.Translation._For} {ev.Amount} {Plugin.Translation.With} {DamageTypes.FromIndex(ev.Tool).name}.**", HandleQueue.GameLogChannelId);
 							}
@@ -201,15 +201,21 @@ namespace DiscordIntegration_Plugin
 			{
 				try
 				{
-					if (ev.Killer != null && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam())
-						ProcessSTT.SendData(
-							$":o: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.Translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.Translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
+					if (ev.Killer != null && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam() || ev.Killer.Role.GetSide() == ev.Target.Role.GetSide())
+						ProcessSTT.SendData($":o: **{ev.Killer.Nickname} - `{ev.Killer.UserId}` ({ev.Killer.Role}) {Plugin.Translation.Killed} {ev.Target.Nickname} - `{ev.Target.UserId}` ({ev.Target.Role}) {Plugin.Translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
 							HandleQueue.GameLogChannelId);
 					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
 					{
-						ProcessSTT.SendData(
-							$":skull_crossbones: **{ev.Killer.Nickname} - {ev.Killer.UserId} ({ev.Killer.Role}) {Plugin.Translation.Killed} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.Translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
-							HandleQueue.GameLogChannelId);
+						if (ev.Killer != null && ev.Killer != ev.Target && ev.Target.Role.GetTeam() == ev.Killer.Role.GetTeam() || ev.Killer.Role.GetSide() == ev.Target.Role.GetSide())
+						{
+							ProcessSTT.SendData($":o: **{ev.Killer.Nickname} - `{ev.Killer.UserId}` ({ev.Killer.Role}) {Plugin.Translation.Killed} {ev.Target.Nickname} - `{ev.Target.UserId}` ({ev.Target.Role}) {Plugin.Translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
+								HandleQueue.GameLogChannelId);
+						}
+						else
+						{
+							ProcessSTT.SendData($":skull_crossbones: **{ev.Killer.Nickname} - `{ev.Killer.UserId}` ({ev.Killer.Role}) {Plugin.Translation.Killed} {ev.Target.Nickname} - `{ev.Target.UserId}` ({ev.Target.Role}) {Plugin.Translation.With} {DamageTypes.FromIndex(ev.HitInformation.Tool).name}.**",
+								HandleQueue.GameLogChannelId);
+						}
 					}
 				}
 				catch (Exception e)

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -284,8 +284,21 @@ namespace DiscordIntegration_Plugin
 
 		public void OnPlayerBanned(BannedEventArgs ev)
 		{
-			if (Plugin.Singleton.Config.Banned)
-				ProcessSTT.SendData($":no_entry: {ev.Details.OriginalName} - {ev.Details.Id} {Plugin.Translation.WasBannedBy} {ev.Details.Issuer} {Plugin.Translation._For} {ev.Details.Reason}. {new DateTime(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
+			if (Plugin.Singleton.Config.ShowIpAddresses)
+			{
+				ProcessSTT.SendData($":no_entry: {ev.Details.OriginalName} - `{ev.Details.Id}` {Plugin.Translation.WasBannedBy} {ev.Details.Issuer} {Plugin.Translation._For} {ev.Details.Reason}. {new DateTime(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
+			}
+			else
+			{
+				if (ev.Details.Id.ToString().Contains("."))
+				{
+					ProcessSTT.SendData($":no_entry: {ev.Details.OriginalName} - `IP Hidden` {Plugin.Translation.WasBannedBy} {ev.Details.Issuer} {Plugin.Translation._For} {ev.Details.Reason}. {new DateTime(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
+				}
+				else
+				{
+					ProcessSTT.SendData($":no_entry: {ev.Details.OriginalName} - `{ev.Details.Id}` {Plugin.Translation.WasBannedBy} {ev.Details.Issuer} {Plugin.Translation._For} {ev.Details.Reason}. {new DateTime(ev.Details.Expires)}", HandleQueue.CommandLogChannelId);
+				}
+			}
 		}
 
 		public void OnIntercomSpeak(IntercomSpeakingEventArgs ev)

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -163,15 +163,29 @@ namespace DiscordIntegration_Plugin
 			{
 				try
 				{
-					if (ev.Attacker != null && ev.Target.Role.GetTeam() == ev.Attacker.Role.GetTeam() && ev.Target != ev.Attacker)
-						ProcessSTT.SendData(
-							$":crossed_swords: **{ev.Attacker.Nickname} - {ev.Attacker.UserId} ({ev.Attacker.Role}) {Plugin.Translation.Damaged} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.Translation._For} {ev.Amount} {Plugin.Translation.With} {DamageTypes.FromIndex(ev.Tool).name}.**",
-							HandleQueue.GameLogChannelId);
-					else if (!Plugin.Singleton.Config.OnlyFriendlyFire)
+					string scp = "SCP-207";
+					if (DamageTypes.FromIndex(ev.Tool).name == scp)
 					{
-						ProcessSTT.SendData(
-								$"{ev.HitInformations.Attacker}  {Plugin.Translation.Damaged} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.Translation._For} {ev.Amount} {Plugin.Translation.With} {DamageTypes.FromIndex(ev.Tool).name}.",
-								HandleQueue.GameLogChannelId);
+						//
+					}
+					else
+					{
+						if (ev.Attacker != null && ev.Target != ev.Attacker && ev.Target.Role.GetTeam() == ev.Attacker.Role.GetTeam() || ev.Attacker.Role.GetSide() == ev.Target.Role.GetSide())
+						{
+							ProcessSTT.SendData($":crossed_swords: **{ev.Attacker.Nickname} - `{ev.Attacker.UserId}` ({ev.Attacker.Role}) {Plugin.Translation.Damaged} {ev.Target.Nickname} - `{ev.Target.UserId}` ({ev.Target.Role}) {Plugin.Translation._For} {ev.Amount} {Plugin.Translation.With} {DamageTypes.FromIndex(ev.Tool).name}.**", HandleQueue.GameLogChannelId);
+						}
+						else if (!Plugin.Singleton.Config.OnlyFriendlyFireDMG)
+						{
+							if (ev.Attacker != null && ev.Target.Role.GetTeam() == ev.Attacker.Role.GetTeam() && ev.Target != ev.Attacker)
+							{
+								ProcessSTT.SendData($":crossed_swords: **{ev.Attacker.Nickname} - `{ev.Attacker.UserId}` ({ev.Attacker.Role}) {Plugin.Translation.Damaged} {ev.Target.Nickname} - `{ev.Target.UserId}` ({ev.Target.Role}) {Plugin.Translation._For} {ev.Amount} {Plugin.Translation.With} {DamageTypes.FromIndex(ev.Tool).name}.**", HandleQueue.GameLogChannelId);
+							}
+							else
+							{
+								//ProcessSTT.SendData($"{ev.HitInformations.Attacker}  {Plugin.Translation.Damaged} {ev.Target.Nickname} - {ev.Target.UserId} ({ev.Target.Role}) {Plugin.Translation._For} {ev.Amount} {Plugin.Translation.With} {DamageTypes.FromIndex(ev.Tool).name}.", HandleQueue.GameLogChannelId);
+								ProcessSTT.SendData($"{ev.Attacker.Nickname} - `{ev.Attacker.UserId}` ({ev.Attacker.Role}) {Plugin.Translation.Damaged} {ev.Target.Nickname} - `{ev.Target.UserId}` ({ev.Target.Role}) {Plugin.Translation._For} {ev.Amount} {Plugin.Translation.With} {DamageTypes.FromIndex(ev.Tool).name}.", HandleQueue.GameLogChannelId);
+							}
+						}
 					}
 				}
 				catch (Exception e)

--- a/DiscordIntegration/PlayerEvents.cs
+++ b/DiscordIntegration/PlayerEvents.cs
@@ -312,12 +312,18 @@ namespace DiscordIntegration_Plugin
 			{
 				if (Plugin.Singleton.Config.SetGroup)
 				{
-					string roleMessage = ev.NewGroup == null
-						? "None"
-						: $"{ev.NewGroup.BadgeText} ({ev.NewGroup.BadgeColor})";
-					ProcessSTT.SendData(
-						$"{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.Translation.GroupSet}: **{roleMessage}**.",
-						HandleQueue.GameLogChannelId);
+					if (ev.NewGroup == null)
+					{
+						string roleMessage = "None";
+						ProcessSTT.SendData($"{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.Translation.GroupSet}: **{roleMessage}**.",
+							HandleQueue.GameLogChannelId);
+					}
+					else
+					{
+						string roleMessage = $"{ev.NewGroup.BadgeText} ({ev.NewGroup.BadgeColor})";
+						ProcessSTT.SendData($"{ev.Player.Nickname} - {ev.Player.UserId} {Plugin.Translation.GroupSet}: **{roleMessage}**.",
+							HandleQueue.GameLogChannelId);
+					}
 				}
 			}
 			catch (Exception e)

--- a/DiscordIntegration_Bot/ProcessSTT.cs
+++ b/DiscordIntegration_Bot/ProcessSTT.cs
@@ -234,8 +234,8 @@ namespace DiscordIntegration_Bot
 					await Bot.Client.SetActivityAsync(new Game(status));
 					return;
 				}
-				data.Data = data.Data.Substring(data.Data.IndexOf('#') + 1);
-
+				//data.Data = data.Data.Substring(data.Data.IndexOf('#') + 1);
+				//Disabled to fix broken names, if it includes a #
 				
 				
 				Console.WriteLine("Getting guild.");


### PR DESCRIPTION
- Discord names and steam names that have # should no longer break the messages (thanks to iD4NG3R`)
- SCP-207 damage spam is fixed
- New config line to enable only friendly fire damage
- Fixed #19 
- Hide IP address in ban message if showing them is disabled in config

All changes were tested and should work on other servers